### PR TITLE
fixed css not loading on dev and production webpack issue

### DIFF
--- a/client/index.tsx
+++ b/client/index.tsx
@@ -8,6 +8,8 @@ import App from './App';
 const rootElement = createRoot(document.getElementById('root'));
 rootElement.render(
   <Provider store={store}>
-    <App />
+    <div>
+      <App />
+    </div>
   </Provider>
 );

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -2,13 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link src="../stylesheets/styles.css" rel="stylesheet" />
+    <link href="../dist/styles.css" rel="stylesheet" />
     <!-- <script src="./node_modules/flowbite/dist/flowbite.min.js"></script> -->
 
     <title>Kale: Kubernetes GPU Monitoring and Autoscaling tool</title>
   </head>
   <body class="bg-gray-50 dark:bg-zinc-950">
     <div id="root"></div>
-    <script src="bundle.js"></script>
+    <script src="../../dist/bundle.js"></script>
   </body>
 </html>

--- a/server/server.ts
+++ b/server/server.ts
@@ -10,7 +10,8 @@ const PORT = 3000;
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
-app.use('/public', express.static(path.resolve(__dirname, '../client/public')));
+//app.use('/public', express.static(path.resolve(__dirname, '../client/public')));
+app.use('/dist', express.static(path.resolve(__dirname, '../dist')));
 
 app.get('/', (req, res) => {
   return res

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,11 +4,11 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 module.exports = {
   entry: './client/index.tsx',
+  mode: process.env.NODE_ENV,
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: 'bundle.js',
   },
-  mode: process.env.NODE_ENV,
   devServer: {
     historyApiFallback: true,
     static: {
@@ -17,13 +17,15 @@ module.exports = {
     },
     proxy: [
       {
-        context: ['/', '/api', '/snapshots'],
+        context: ['/api', '/snapshots'],
         target: 'http://localhost:3000',
       },
     ],
   },
   plugins: [
-    new MiniCssExtractPlugin(),
+    new MiniCssExtractPlugin({
+      filename: 'styles.css',
+    }),
     new HtmlWebpackPlugin({
       title: 'development',
       template: './client/public/index.html',


### PR DESCRIPTION
## 🔗 Linked issue

Resolved CSS not loading in production/development mode in webpack bundling

## Description

fixed webpack proxy and initial index html file to have correct address to bundle files
